### PR TITLE
Add create-react-class to support React 15.5 or greater

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,36 +1,29 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
-
-var _react = require('react');
-
-var _react2 = _interopRequireDefault(_react);
-
-exports['default'] = function (component) {
-  var opts = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+exports.default = function (component) {
+  var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
   if (!component) {
-    throw new Error('\n      [ReactStateless.createClass(component)] stateless needs a component\n    ');
+    throw new Error('\n      [createReactClass(component)] stateless needs a component\n    ');
   }
 
   component = component instanceof Function ? _extends({ render: component }, component) : component;
 
   if (!('render' in component)) {
-    throw new Error('\n      [ReactStateless.createClass(component)] No render function found.\n      "component" should be a render function or contain a render function.\n    ');
+    throw new Error('\n      [createReactClass(component)] No render function found.\n      "component" should be a render function or contain a render function.\n    ');
   }
 
   component = _extends({}, component, opts);
 
-  var _component = component;
-  var _render = _component.render;
+  var _component = component,
+    _render = _component.render;
+
 
   var displayName = _render.name;
 
@@ -53,16 +46,26 @@ exports['default'] = function (component) {
       var _component2;
 
       if (!this) throw Error('NO CONTEXT');
-      var props = this.props;
-      var refs = this.refs;
+      var props = this.props,
+        refs = this.refs;
 
       return (_component2 = component)[m].apply(_component2, _toConsumableArray([props, input, refs, this].filter(Boolean)));
     };
     return o;
   }, {}));
 
-  return _react2['default'].createClass(spec);
+  return (0, _createReactClass2.default)(spec);
 };
 
-module.exports = exports['default'];
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _createReactClass = require('create-react-class');
+
+var _createReactClass2 = _interopRequireDefault(_createReactClass);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "react": "^15.0.0"
+    "create-react-class": "^15.6.0",
+    "react": "15.6.1"
   },
   "devDependencies": {
     "assert": "^1.3.0",
     "babel-core": "^5.8.25",
     "babel-tap": "^4.0.0",
-    "react-dom": "^15.0.0",
+    "react-dom": "^15.6.1",
     "react-shallow-renderer": "^1.1.4"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "create-react-class": "^15.6.0",
-    "react": "15.6.1"
+    "react": "^15.6.1"
   },
   "devDependencies": {
     "assert": "^1.3.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,20 @@
 import React from 'react'
+import createReactClass from 'create-react-class'
 
 export default function (component, opts = {}) {
   if (!component) {
-     throw new Error(`
-      [ReactStateless.createClass(component)] stateless needs a component
+    throw new Error(`
+      [createReactClass(component)] stateless needs a component
     `)
   }
 
   component = (component instanceof Function) ?
-    {render: component, ...component} :
+  {render: component, ...component} :
     component
 
   if (!('render' in component)) {
     throw new Error(`
-      [ReactStateless.createClass(component)] No render function found.
+      [createReactClass(component)] No render function found.
       "component" should be a render function or contain a render function.
     `)
   }
@@ -41,7 +42,7 @@ export default function (component, opts = {}) {
     'displayName'
   ]
 
-  const spec = { 
+  const spec = {
     displayName,
     render: function () { return render(this.props, this) },
     ...properties.reduce((o, p) => {
@@ -60,6 +61,6 @@ export default function (component, opts = {}) {
     }, {})
   }
 
-  return React.createClass(spec)
+  return createReactClass(spec)
 
 }


### PR DESCRIPTION
Added "create-react-class" in order to remove the deprecated React.createClass. Compatible with <15.4 and >15.5. Tested in one project with React 15.6.1.