### PR TITLE
Don't use global install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Add life cycle methods to stateless functional components,
 without the class noise. 
 
 ```sh
-npm i -g --save react-functional
+npm i --save react-functional
 ```
 
 ## functional(component)


### PR DESCRIPTION
I think it probably makes sense to locally install this module. Global installations of node packages are usually discouraged since they tie your application to the global state of your machine. Sometimes dev tooling is an exception, but this seems like a runtime dependency 😀